### PR TITLE
Hotfix/comments

### DIFF
--- a/src/hooks/useProfileChange.js
+++ b/src/hooks/useProfileChange.js
@@ -3,6 +3,7 @@ import { fetchUserById, updateContact } from "@/services/authService";
 import { toast } from "./use-toast";
 import {
   sendChangeEmailVerification,
+  toggleNotification,
   updateEmail,
   updateName,
 } from "@/services/userService";
@@ -50,7 +51,7 @@ export const useProfileChange = ({
       });
     },
     onSettled: () => {
-      queryClient.invalidateQueries(["fetchUser",user_id]);
+      queryClient.invalidateQueries(["fetchUser", user_id]);
       setIsDialogOpen(false);
     },
   });
@@ -73,7 +74,7 @@ export const useProfileChange = ({
       });
     },
     onSettled: () => {
-      queryClient.invalidateQueries(["fetchUser",user_id]);
+      queryClient.invalidateQueries(["fetchUser", user_id]);
     },
   });
 
@@ -93,7 +94,7 @@ export const useProfileChange = ({
       });
     },
     onSettled: () => {
-      queryClient.invalidateQueries(["fetchUser",user_id]);
+      queryClient.invalidateQueries(["fetchUser", user_id]);
       setIsEmailDialogOpen(false);
     },
   });
@@ -114,7 +115,7 @@ export const useProfileChange = ({
       });
     },
     onSettled: () => {
-      queryClient.invalidateQueries(["fetchUser",user_id]);
+      queryClient.invalidateQueries(["fetchUser", user_id]);
       setIsNameDialogOpen(false);
     },
   });
@@ -142,6 +143,25 @@ export const useProfileChange = ({
       data.subscription.unsubscribe();
     };
   }, [data]);
+  const toggleNotificationMutation = useMutation({
+    mutationFn: async (data) => toggleNotification(data),
+    onSuccess: () => {
+      toast({
+        title: "Notification has been updated",
+      });
+    },
+    onError: (error) => {
+      toast({
+        title: "Error Updating Notification",
+        description:
+          error?.message || "Something went wrong. Please try again.",
+        variant: "destructive",
+      });
+    },
+    onSettled: () => {
+      queryClient.invalidateQueries(["fetchUser", user_id]);
+    },
+  });
 
   return {
     sendEmailLinkMutation,
@@ -150,5 +170,6 @@ export const useProfileChange = ({
     isLoading,
     updateEmailMutation,
     updateNameMutation,
+    toggleNotificationMutation,
   };
 };

--- a/src/pages/Profile.jsx
+++ b/src/pages/Profile.jsx
@@ -28,6 +28,7 @@ import {
 import Loading from "@/components/Loading";
 import { Label } from "@/components/ui/label";
 import { Link } from "react-router-dom";
+import { Switch } from "@/components/ui/switch";
 
 const Profile = () => {
   const { userData } = useUser();
@@ -59,6 +60,7 @@ const Profile = () => {
   });
 
   const {
+    toggleNotificationMutation,
     updateNameMutation,
     sendEmailLinkMutation,
     updateContactMutation,
@@ -97,6 +99,12 @@ const Profile = () => {
     updateContactMutation.mutate({
       userId: userData?.id,
       newContactNumber: newContact.contact_number,
+    });
+  };
+  const toggleNotification = async (userId, isReceivingNotification) => {
+    toggleNotificationMutation.mutate({
+      userId,
+      isReceivingNotification,
     });
   };
 
@@ -329,6 +337,15 @@ const Profile = () => {
             </Dialog>
           </div>
           <p className="text-gray-700">{data?.contact_number}</p>
+          <div className="flex items-center justify-between">
+            <p>Email Notification</p>
+            <Switch
+              defaultChecked={data.is_receiving_notification}
+              onCheckedChange={() =>
+                toggleNotification(userData.id, !data.is_receiving_notification)
+              }
+            />
+          </div>
         </div>
         <div className="flex justify-end">
           <Link

--- a/src/services/userService.js
+++ b/src/services/userService.js
@@ -221,6 +221,18 @@ const updateName = async ({ userId, first_name, last_name }) => {
     throw new Error("Error pupdating parent name", error.message);
   }
 };
+const toggleNotification = async ({ userId, isReceivingNotification }) => {
+  const { error } = await supabase
+    .from("users")
+    .update({
+      email_notifications_enabled: isReceivingNotification,
+    })
+    .eq("id", userId);
+
+  if (error) {
+    throw new Error("Error updating notification!", error.message);
+  }
+};
 
 export {
   getUser,
@@ -235,4 +247,5 @@ export {
   updateEmail,
   updateName,
   resetPassword,
+  toggleNotification,
 };


### PR DESCRIPTION
This pull request introduces functionality to toggle email notifications for users. The changes include updates to the `useProfileChange` hook, the `Profile` page, and the user service to support this new feature.

### Updates to the `useProfileChange` hook:
* Added `toggleNotification` to the list of imports in `src/hooks/useProfileChange.js` to utilize the new service for toggling notifications.
* Introduced a `toggleNotificationMutation` using `useMutation` to handle the toggle operation, including success and error handling with user feedback via toast notifications.
* Exposed `toggleNotificationMutation` in the return object of the hook to make it available for use in components.

### Updates to the `Profile` page:
* Imported the `Switch` component from the UI library in `src/pages/Profile.jsx` to create a toggle interface for email notifications.
* Added `toggleNotificationMutation` to the destructured hook return values and implemented a `toggleNotification` function to call the mutation. [[1]](diffhunk://#diff-e51a0c6507b93c0bceb3c50618ce285d7255c500452509ac388af36ad368f8e1R63) [[2]](diffhunk://#diff-e51a0c6507b93c0bceb3c50618ce285d7255c500452509ac388af36ad368f8e1R104-R109)
* Integrated the `Switch` component into the UI, allowing users to toggle email notifications directly from the profile page. The component updates the notification setting via the `toggleNotification` function.

### Updates to the user service:
* Added a new `toggleNotification` function in `src/services/userService.js` to update the `email_notifications_enabled` field in the database for a given user. This function throws an error if the update fails.
* Exported the `toggleNotification` function to make it accessible for use in other parts of the application.