### PR TITLE
Update FinalizePoll

### DIFF
--- a/src/components/Poll-Management/FinalizePoll.jsx
+++ b/src/components/Poll-Management/FinalizePoll.jsx
@@ -13,9 +13,9 @@ import { parseISO, format, setHours, setMinutes } from "date-fns";
 import PropTypes from "prop-types";
 import usePoll from "@/hooks/usePoll";
 import { useState } from "react";
-import { Loader2 } from "lucide-react";
+import { CheckCircle2, Loader2, Send } from "lucide-react";
 
-const FinalizePoll = ({ pollId, pollDate, pollTime }) => {
+const FinalizePoll = ({ pollId, pollDate, pollTime, isFinalised }) => {
   const [open, setOpen] = useState(false);
   const { finalizePollMutation } = usePoll({ poll_id: pollId });
 
@@ -49,11 +49,39 @@ const FinalizePoll = ({ pollId, pollDate, pollTime }) => {
     );
   };
 
+  // Get button text and style based on finalized status
+  const getButtonContent = () => {
+    if (finalizePollMutation.isPending) {
+      return (
+        <>
+          <Loader2 className="mr-2 h-4 w-4 animate-spin" />
+          Finalising...
+        </>
+      );
+    }
+
+    if (isFinalised) {
+      return (
+        <>
+          <CheckCircle2 className="mr-2 h-4 w-4" />
+          Already finalised (Resend)
+        </>
+      );
+    }
+
+    return (
+      <>
+        <Send className="mr-2 h-4 w-4" />
+        Finalise and send announcement
+      </>
+    );
+  };
+
   return (
     <AlertDialog open={open} onOpenChange={setOpen}>
       <AlertDialogTrigger asChild>
         <Button className="w-full bg-primary text-[14px] text-accent">
-          Finalise and send announcement
+          {getButtonContent()}
         </Button>
       </AlertDialogTrigger>
       <AlertDialogContent>
@@ -63,6 +91,12 @@ const FinalizePoll = ({ pollId, pollDate, pollTime }) => {
             This action will finalise the poll results for{" "}
             <strong>{formattedDateTime}</strong> and send an announcement to all
             participants. This cannot be undone.
+            {finalizePollMutation.isPending && (
+              <p className="mt-2 text-danger">
+                Please wait, it will take a few minutes to send an announcement
+                to all participants.
+              </p>
+            )}
           </AlertDialogDescription>
         </AlertDialogHeader>
         <AlertDialogFooter>
@@ -92,6 +126,7 @@ FinalizePoll.propTypes = {
   pollDate: PropTypes.string.isRequired, // ISO date string
   pollTime: PropTypes.string.isRequired, // "HH:mm" format
   pollId: PropTypes.string.isRequired, // Poll ID for finalization
+  isFinalised: PropTypes.bool.isRequired, // Whether the poll is already finalised
 };
 
 export default FinalizePoll;

--- a/src/components/Poll-Management/PollInformation.jsx
+++ b/src/components/Poll-Management/PollInformation.jsx
@@ -110,14 +110,15 @@ const PollInformation = ({ poll, isMobile, isSheetOpen, setSheetOpen }) => {
           </div>
         </div>
         <PollEntries
-          poll_id={poll.id}
-          pollName={poll.name}
+          poll_id={poll?.id}
+          pollName={poll?.name}
           dates={dates}
           isLoading={datesLoading}
           isError={datesError}
           error={datesErrorMsg}
           addTimeSlotMutation={addTimeSlotMutation}
           isExpired={isExpired}
+          isFinalised={poll?.is_finalised}
         />
       </div>
     </div>
@@ -174,7 +175,7 @@ PollInformation.propTypes = {
     name: PropTypes.string,
     description: PropTypes.string,
     expiration_date: PropTypes.string,
-
+    is_finalised: PropTypes.bool,
     responses: PropTypes.number,
   }),
   isMobile: PropTypes.bool,
@@ -191,6 +192,7 @@ const PollEntries = ({
   addTimeSlotMutation,
   isExpired,
   poll_id,
+  isFinalised,
 }) => {
   const [activeTimePickerIndex, setActiveTimePickerIndex] = useState(null);
 
@@ -253,6 +255,7 @@ const PollEntries = ({
                               pollId={poll_id}
                               pollDate={date.date}
                               pollTime={time.time}
+                              isFinalised={isFinalised}
                             />
                           )}
                       </>
@@ -321,6 +324,7 @@ PollEntries.propTypes = {
   addTimeSlotMutation: PropTypes.object.isRequired,
   isExpired: PropTypes.bool.isRequired,
   poll_id: PropTypes.string.isRequired,
+  isFinalised: PropTypes.bool.isRequired,
 };
 
 const DeletePoll = ({ poll_id }) => {


### PR DESCRIPTION
This pull request introduces enhancements to the poll management components by adding support for handling finalized polls. The changes primarily focus on improving the user interface and logic for displaying finalized poll statuses and ensuring the necessary data is passed between components.

### Enhancements to `FinalizePoll` Component:

* Added a new `isFinalised` prop to indicate whether a poll is already finalized, along with corresponding UI updates to display appropriate button content based on the finalized status. [[1]](diffhunk://#diff-3402de532573c04f5e31fe2d05f08390321b9ffb99a28880787e3e93ada81141L16-R18) [[2]](diffhunk://#diff-3402de532573c04f5e31fe2d05f08390321b9ffb99a28880787e3e93ada81141R52-R84)
* Included a message in the dialog to inform users about the pending status when finalizing a poll, improving user feedback during asynchronous operations.
* Updated `FinalizePoll.propTypes` to require the `isFinalised` prop for better type checking.

### Updates to `PollInformation` Component:

* Passed the new `is_finalised` property from the `poll` object to the `PollEntries` component to propagate finalized status across the UI. [[1]](diffhunk://#diff-5dfdf7add29b3ca72d81d3410b0291871b46bad633e2fb7c0eabb1d387cdf2d2L113-R121) [[2]](diffhunk://#diff-5dfdf7add29b3ca72d81d3410b0291871b46bad633e2fb7c0eabb1d387cdf2d2L177-R178)
* Updated `PollEntries.propTypes` to include the new `isFinalised` prop for type validation.

### Updates to `PollEntries` Component:

* Added the `isFinalised` prop to the `PollEntries` component and ensured it is passed down to the `FinalizePoll` component for consistent handling of finalized polls. [[1]](diffhunk://#diff-5dfdf7add29b3ca72d81d3410b0291871b46bad633e2fb7c0eabb1d387cdf2d2R195) [[2]](diffhunk://#diff-5dfdf7add29b3ca72d81d3410b0291871b46bad633e2fb7c0eabb1d387cdf2d2R258)